### PR TITLE
Remove AXI_ERROR_RESP_G

### DIFF
--- a/DpmCore/hdl/DpmCore.vhd
+++ b/DpmCore/hdl/DpmCore.vhd
@@ -5,7 +5,7 @@
 -- Author     : Ryan Herbst <rherbst@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-11-14
--- Last update: 2016-10-21
+-- Last update: 2018-03-08
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -123,9 +123,9 @@ architecture STRUCTURE of DpmCore is
    signal idmaIbMaster        : AxiStreamMasterArray(3 downto 0);
    signal idmaIbSlave         : AxiStreamSlaveArray(3 downto 0);
    signal coreAxilReadMaster  : AxiLiteReadMasterType;
-   signal coreAxilReadSlave   : AxiLiteReadSlaveType;
+   signal coreAxilReadSlave   : AxiLiteReadSlaveType := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    signal coreAxilWriteMaster : AxiLiteWriteMasterType;
-   signal coreAxilWriteSlave  : AxiLiteWriteSlaveType;
+   signal coreAxilWriteSlave  : AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
    signal armEthTx            : ArmEthTxArray(1 downto 0);
    signal armEthRx            : ArmEthRxArray(1 downto 0);
    signal armEthMode          : slv(31 downto 0);
@@ -264,17 +264,7 @@ begin
       armEthRx(1)        <= ARM_ETH_RX_INIT_C;
       armEthMode         <= x"00000001";  -- 1 Gig on lane 0
 
-      U_AxiLiteEmpty : entity work.AxiLiteEmpty
-         generic map (
-            TPD_G => TPD_G) 
-         port map (
-            axiClk         => iaxiClk,
-            axiClkRst      => iaxiClkRst,
-            axiReadMaster  => coreAxilReadMaster,
-            axiReadSlave   => coreAxilReadSlave,
-            axiWriteMaster => coreAxilWriteMaster,
-            axiWriteSlave  => coreAxilWriteSlave);
-   end generate;
+    end generate;
 
    U_Eth10gGen : if ETH_10G_EN_G = true generate
       U_ZynqEthernet10G : entity work.ZynqEthernet10G

--- a/EvalCore/hdl/EvalCore.vhd
+++ b/EvalCore/hdl/EvalCore.vhd
@@ -82,9 +82,9 @@ architecture STRUCTURE of EvalCore is
    signal idmaIbMaster        : AxiStreamMasterArray(3 downto 0);
    signal idmaIbSlave         : AxiStreamSlaveArray(3 downto 0);
    signal coreAxilReadMaster  : AxiLiteReadMasterType;
-   signal coreAxilReadSlave   : AxiLiteReadSlaveType;
+   signal coreAxilReadSlave   : AxiLiteReadSlaveType := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    signal coreAxilWriteMaster : AxiLiteWriteMasterType;
-   signal coreAxilWriteSlave  : AxiLiteWriteSlaveType;
+   signal coreAxilWriteSlave  : AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
 
 begin
 
@@ -152,19 +152,6 @@ begin
    idmaClkRst(3)   <= isysClk125Rst;
    idmaObSlave(3)  <= AXI_STREAM_SLAVE_INIT_C;
    idmaIbMaster(3) <= AXI_STREAM_MASTER_INIT_C;
-
-   -- Terminate Unused AXI-Lite Interface
-   U_AxiLiteEmpty : entity work.AxiLiteEmpty
-      generic map (
-         TPD_G  => TPD_G
-      ) port map (
-         axiClk          => iaxiClk,
-         axiClkRst       => iaxiClkRst,
-         axiReadMaster   => coreAxilReadMaster,
-         axiReadSlave    => coreAxilReadSlave,
-         axiWriteMaster  => coreAxilWriteMaster,
-         axiWriteSlave   => coreAxilWriteSlave
-      );
 
 end architecture STRUCTURE;
 

--- a/PpiCommon/tb/axis_tb.vhd
+++ b/PpiCommon/tb/axis_tb.vhd
@@ -221,7 +221,6 @@ begin
          generic map (
             TPD_G                      => 1 ns,
             STATUS_CNT_WIDTH_G         => 32,
-            AXI_ERROR_RESP_G           => AXI_RESP_SLVERR_C,
             ALTERA_SYN_G               => false,
             ALTERA_RAM_G               => "M9K",
             CASCADE_SIZE_G             => 1,

--- a/PpiPgp/tb/fe_emulate.vhd
+++ b/PpiPgp/tb/fe_emulate.vhd
@@ -311,7 +311,6 @@ begin
       generic map (
          TPD_G                      => 1 ns,
          STATUS_CNT_WIDTH_G         => 32,
-         AXI_ERROR_RESP_G           => AXI_RESP_SLVERR_C,
          ALTERA_SYN_G               => false,
          ALTERA_RAM_G               => "M9K",
          CASCADE_SIZE_G             => 1,

--- a/PpiPgp/tb/interleave_test.vhd
+++ b/PpiPgp/tb/interleave_test.vhd
@@ -288,7 +288,6 @@ begin
             generic map (
                TPD_G                      => 1 ns,
                STATUS_CNT_WIDTH_G         => 32,
-               AXI_ERROR_RESP_G           => AXI_RESP_SLVERR_C,
                ALTERA_SYN_G               => false,
                ALTERA_RAM_G               => "M9K",
                CASCADE_SIZE_G             => 1,

--- a/PpiPgp/tb/pgp_ppi_test.vhd
+++ b/PpiPgp/tb/pgp_ppi_test.vhd
@@ -173,7 +173,6 @@ begin
       generic map (
          TPD_G                      => 1 ns,
          STATUS_CNT_WIDTH_G         => 32,
-         AXI_ERROR_RESP_G           => AXI_RESP_SLVERR_C,
          ALTERA_SYN_G               => false,
          ALTERA_RAM_G               => "M9K",
          CASCADE_SIZE_G             => 1,

--- a/RceG3/hdl/RceG3DmaAxis.vhd
+++ b/RceG3/hdl/RceG3DmaAxis.vhd
@@ -62,7 +62,7 @@ entity RceG3DmaAxis is
       axilReadMaster  : in  AxiLiteReadMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
       axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
       axilWriteMaster : in  AxiLiteWriteMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMTPY_DECERR_C);
+      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
       -- Interrupts
       interrupt       : out slv(DMA_INT_COUNT_C-1 downto 0);
       -- External DMA Interfaces

--- a/RceG3/hdl/RceG3DmaAxis.vhd
+++ b/RceG3/hdl/RceG3DmaAxis.vhd
@@ -60,9 +60,9 @@ entity RceG3DmaAxis is
       userReadMaster  : in  AxiReadMasterType;
       -- Local AXI Lite Bus, 0x600n0000
       axilReadMaster  : in  AxiLiteReadMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
       axilWriteMaster : in  AxiLiteWriteMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMTPY_DECERR_C);
       -- Interrupts
       interrupt       : out slv(DMA_INT_COUNT_C-1 downto 0);
       -- External DMA Interfaces
@@ -114,17 +114,8 @@ begin
    -- Unused Interrupts
    interrupt(DMA_INT_COUNT_C-1 downto 4) <= (others => '0');
 
-   -- Terminate Unused AXI-Lite Interfaces
-   U_AxiLiteEmpty : entity work.AxiLiteEmpty
-      generic map (
-         TPD_G => TPD_G)
-      port map (
-         axiClk         => axiDmaClk,
-         axiClkRst      => axiDmaRst,
-         axiReadMaster  => axilReadMaster(8),
-         axiReadSlave   => axilReadSlave(8),
-         axiWriteMaster => axilWriteMaster(8),
-         axiWriteSlave  => axilWriteSlave(8));
+
+
 
    ------------------------------------------
    -- DMA Channels

--- a/RceG3/hdl/RceG3DmaAxisV2.vhd
+++ b/RceG3/hdl/RceG3DmaAxisV2.vhd
@@ -58,9 +58,9 @@ entity RceG3DmaAxisV2 is
       userReadMaster  : in  AxiReadMasterType;
       -- Local AXI Lite Bus, 0x600n0000
       axilReadMaster  : in  AxiLiteReadMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
       axilWriteMaster : in  AxiLiteWriteMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
       -- Interrupts
       interrupt       : out slv(DMA_INT_COUNT_C-1 downto 0);
       -- External DMA Interfaces
@@ -110,31 +110,6 @@ begin
 
    -- Unused Interrupts
    interrupt(DMA_INT_COUNT_C-1 downto 4) <= (others => '0');
-
-   -- Terminate Unused AXI-Lite Interfaces
-   U_EmptyGen: for i in 0 to 2 generate
-      U_AxiLiteEmpty : entity work.AxiLiteEmpty
-         generic map (
-            TPD_G => TPD_G)
-         port map (
-            axiClk         => axiDmaClk,
-            axiClkRst      => axiDmaRst,
-            axiReadMaster  => axilReadMaster(i*2+1),
-            axiReadSlave   => axilReadSlave(i*2+1),
-            axiWriteMaster => axilWriteMaster(i*2+1),
-            axiWriteSlave  => axilWriteSlave(i*2+1));
-   end generate;
-
-   U_AxiLiteEmpty : entity work.AxiLiteEmpty
-      generic map (
-         TPD_G => TPD_G)
-      port map (
-         axiClk         => axiDmaClk,
-         axiClkRst      => axiDmaRst,
-         axiReadMaster  => axilReadMaster(8),
-         axiReadSlave   => axilReadSlave(8),
-         axiWriteMaster => axilWriteMaster(8),
-         axiWriteSlave  => axilWriteSlave(8));
 
    -------------------------------------------
    -- Version 2 DMA Core For Ethernet

--- a/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
+++ b/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
@@ -242,7 +242,6 @@ begin
          TPD_G             => TPD_G,
          DESC_AWIDTH_G     => 12,
          AXIL_BASE_ADDR_G  => AXIL_BASE_ADDR_G,
-         AXI_ERROR_RESP_G  => AXI_RESP_OK_C,
          AXI_READY_EN_G    => false,
          AXIS_READY_EN_G   => false,
          AXIS_CONFIG_G     => RCEG3_AXIS_DMA_CONFIG_C,

--- a/RceG3/hdl/RceG3DmaQueue4x2.vhd
+++ b/RceG3/hdl/RceG3DmaQueue4x2.vhd
@@ -5,7 +5,7 @@
 -- File       : RceG3DmaQueue4x2.vhd
 -- Author     : M. Kwiatkowski, mkwiatko@slac.stanford.edu
 -- Created    : 2015-05-22
--- Last update: 2015-05-22
+-- Last update: 2018-03-08
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -40,72 +40,72 @@ use work.SsiPkg.all;
 
 entity RceG3DmaQueue4x2 is
    generic (
-      TPD_G                   : time               := 1 ns;
-      DMA_BUF_START_ADDR_G    : slv(31 downto 0)   := x"3C000000";
-      DMA_BUF_SIZE_BITS_G     : integer            := 24;
-      MAX_CSPAD_PKT_SIZE_G    : integer            := 1150000
-   );
+      TPD_G                : time             := 1 ns;
+      DMA_BUF_START_ADDR_G : slv(31 downto 0) := x"3C000000";
+      DMA_BUF_SIZE_BITS_G  : integer          := 24;
+      MAX_CSPAD_PKT_SIZE_G : integer          := 1150000
+      );
    port (
       -- Clock/Reset
-      axiDmaClk           : in  sl;
-      axiDmaRst           : in  sl;
+      axiDmaClk : in sl;
+      axiDmaRst : in sl;
 
       -- AXI ACP Slave
-      acpWriteSlave       : in  AxiWriteSlaveType;
-      acpWriteMaster      : out AxiWriteMasterType;
-      acpReadSlave        : in  AxiReadSlaveType;
-      acpReadMaster       : out AxiReadMasterType;
+      acpWriteSlave  : in  AxiWriteSlaveType;
+      acpWriteMaster : out AxiWriteMasterType;
+      acpReadSlave   : in  AxiReadSlaveType;
+      acpReadMaster  : out AxiReadMasterType;
 
       -- AXI HP Slave
-      hpWriteSlave        : in  AxiWriteSlaveArray(3 downto 0);
-      hpWriteMaster       : out AxiWriteMasterArray(3 downto 0);
-      hpReadSlave         : in  AxiReadSlaveArray(3 downto 0);
-      hpReadMaster        : out AxiReadMasterArray(3 downto 0);
+      hpWriteSlave  : in  AxiWriteSlaveArray(3 downto 0);
+      hpWriteMaster : out AxiWriteMasterArray(3 downto 0);
+      hpReadSlave   : in  AxiReadSlaveArray(3 downto 0);
+      hpReadMaster  : out AxiReadMasterArray(3 downto 0);
 
       -- Local AXI Lite Bus, 0x600n0000
-      axilReadMaster      : in  AxiLiteReadMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilReadSlave       : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilWriteMaster     : in  AxiLiteWriteMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
-      axilWriteSlave      : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilReadMaster  : in  AxiLiteReadMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilReadSlave   : out AxiLiteReadSlaveArray(DMA_AXIL_COUNT_C-1 downto 0)  := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+      axilWriteMaster : in  AxiLiteWriteMasterArray(DMA_AXIL_COUNT_C-1 downto 0);
+      axilWriteSlave  : out AxiLiteWriteSlaveArray(DMA_AXIL_COUNT_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
 
       -- Interrupts
-      interrupt           : out slv(DMA_INT_COUNT_C-1 downto 0);
+      interrupt : out slv(DMA_INT_COUNT_C-1 downto 0);
 
       -- External DMA Interfaces
-      dmaClk              : in  slv(3 downto 0);
-      dmaClkRst           : in  slv(3 downto 0);
-      dmaState            : out RceDmaStateArray(3 downto 0);
-      dmaObMaster         : out AxiStreamMasterArray(3 downto 0);
-      dmaObSlave          : in  AxiStreamSlaveArray(3 downto 0);
-      dmaIbMaster         : in  AxiStreamMasterArray(3 downto 0);
-      dmaIbSlave          : out AxiStreamSlaveArray(3 downto 0)
-   );
+      dmaClk      : in  slv(3 downto 0);
+      dmaClkRst   : in  slv(3 downto 0);
+      dmaState    : out RceDmaStateArray(3 downto 0);
+      dmaObMaster : out AxiStreamMasterArray(3 downto 0);
+      dmaObSlave  : in  AxiStreamSlaveArray(3 downto 0);
+      dmaIbMaster : in  AxiStreamMasterArray(3 downto 0);
+      dmaIbSlave  : out AxiStreamSlaveArray(3 downto 0)
+      );
 end RceG3DmaQueue4x2;
 
-architecture structure of RceG3DmaQueue4x2 is 
+architecture structure of RceG3DmaQueue4x2 is
 
-   signal locReadMaster    : AxiReadMasterArray(3 downto 0);
-   signal locReadSlave     : AxiReadSlaveArray(3 downto 0);
-   signal locWriteMaster   : AxiWriteMasterArray(3 downto 0);
-   signal locWriteSlave    : AxiWriteSlaveArray(3 downto 0);
-   signal locWriteCtrl     : AxiCtrlArray(3 downto 0);
-   signal intWriteSlave    : AxiWriteSlaveArray(3 downto 0);
-   signal intWriteMaster   : AxiWriteMasterArray(3 downto 0);
-   signal intReadSlave     : AxiReadSlaveArray(3 downto 0);
-   signal intReadMaster    : AxiReadMasterArray(3 downto 0);
-   signal sAxisMaster      : AxiStreamMasterArray(3 downto 0);
-   signal sAxisSlave       : AxiStreamSlaveArray(3 downto 0);
-   signal mAxisMaster      : AxiStreamMasterArray(3 downto 0);
-   signal mAxisSlave       : AxiStreamSlaveArray(3 downto 0);
-   signal mAxisCtrl        : AxiStreamCtrlArray(3 downto 0);
-   
-   signal obAck            : AxiReadDmaAckArray(1 downto 0);
-   signal obReq            : AxiReadDmaReqArray(1 downto 0);
-   signal ibAck            : AxiWriteDmaAckArray(3 downto 0);
-   signal ibReq            : AxiWriteDmaReqArray(3 downto 0);
-   
-   constant DMA_BUFF_MAX_ADDR_C : slv(31 downto 0)   := x"40000000";
-   
+   signal locReadMaster  : AxiReadMasterArray(3 downto 0);
+   signal locReadSlave   : AxiReadSlaveArray(3 downto 0);
+   signal locWriteMaster : AxiWriteMasterArray(3 downto 0);
+   signal locWriteSlave  : AxiWriteSlaveArray(3 downto 0);
+   signal locWriteCtrl   : AxiCtrlArray(3 downto 0);
+   signal intWriteSlave  : AxiWriteSlaveArray(3 downto 0);
+   signal intWriteMaster : AxiWriteMasterArray(3 downto 0);
+   signal intReadSlave   : AxiReadSlaveArray(3 downto 0);
+   signal intReadMaster  : AxiReadMasterArray(3 downto 0);
+   signal sAxisMaster    : AxiStreamMasterArray(3 downto 0);
+   signal sAxisSlave     : AxiStreamSlaveArray(3 downto 0);
+   signal mAxisMaster    : AxiStreamMasterArray(3 downto 0);
+   signal mAxisSlave     : AxiStreamSlaveArray(3 downto 0);
+   signal mAxisCtrl      : AxiStreamCtrlArray(3 downto 0);
+
+   signal obAck : AxiReadDmaAckArray(1 downto 0);
+   signal obReq : AxiReadDmaReqArray(1 downto 0);
+   signal ibAck : AxiWriteDmaAckArray(3 downto 0);
+   signal ibReq : AxiWriteDmaReqArray(3 downto 0);
+
+   constant DMA_BUFF_MAX_ADDR_C : slv(31 downto 0) := x"40000000";
+
    constant CUSTOM_AXIS_DMA_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => 4,
@@ -114,47 +114,47 @@ architecture structure of RceG3DmaQueue4x2 is
       TKEEP_MODE_C  => TKEEP_COMP_C,
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
-   
-   constant CUSTOM_AXIS_DMA_ADDR_C : Slv32Array(3 downto 0) := ( 
+
+   constant CUSTOM_AXIS_DMA_ADDR_C : Slv32Array(3 downto 0) := (
       DMA_BUF_START_ADDR_G+2**DMA_BUF_SIZE_BITS_G*3,
       DMA_BUF_START_ADDR_G+2**DMA_BUF_SIZE_BITS_G*2,
       DMA_BUF_START_ADDR_G+2**DMA_BUF_SIZE_BITS_G,
       DMA_BUF_START_ADDR_G);
-   
-   constant DMA_BUFF_COUNT_C : integer := (2**DMA_BUF_SIZE_BITS_G)/MAX_CSPAD_PKT_SIZE_G;
-   signal wrBuffIndex : IntegerArray(3 downto 0) := (0,0,0,0);
-   signal rdBuffIndex : IntegerArray(3 downto 0) := (0,0,0,0);
-   signal cntUsedBuff : IntegerArray(3 downto 0) := (0,0,0,0);
-   signal buffOffsets : IntegerArray(DMA_BUFF_COUNT_C-1 downto 0);
-   
+
+   constant DMA_BUFF_COUNT_C : integer                  := (2**DMA_BUF_SIZE_BITS_G)/MAX_CSPAD_PKT_SIZE_G;
+   signal wrBuffIndex        : IntegerArray(3 downto 0) := (0, 0, 0, 0);
+   signal rdBuffIndex        : IntegerArray(3 downto 0) := (0, 0, 0, 0);
+   signal cntUsedBuff        : IntegerArray(3 downto 0) := (0, 0, 0, 0);
+   signal buffOffsets        : IntegerArray(DMA_BUFF_COUNT_C-1 downto 0);
+
    type BuffAddrArray is array (natural range <>) of slv(DMA_BUF_SIZE_BITS_G-1 downto 0);
-   
-   signal ibAcqFifoOut        : BuffAddrArray(3 downto 0);
-   signal ibAcqFifoWrFull     : slv(3 downto 0);
-   signal ibAcqFifoEmpty      : slv(3 downto 0);
-   signal ibAcqFifoRd         : slv(3 downto 0);
-   signal ibAckDoneD1         : slv(3 downto 0);
-   signal ibAckRes            : slv(3 downto 0);
-   signal wrPending           : slv(3 downto 0);
-   signal wrChannelSel        : IntegerArray(1 downto 0);
-   
+
+   signal ibAcqFifoOut    : BuffAddrArray(3 downto 0);
+   signal ibAcqFifoWrFull : slv(3 downto 0);
+   signal ibAcqFifoEmpty  : slv(3 downto 0);
+   signal ibAcqFifoRd     : slv(3 downto 0);
+   signal ibAckDoneD1     : slv(3 downto 0);
+   signal ibAckRes        : slv(3 downto 0);
+   signal wrPending       : slv(3 downto 0);
+   signal wrChannelSel    : IntegerArray(1 downto 0);
+
    type StateType is (S_IDLE_C, S_READ_0_C, S_READ_1_C, S_DONE_0_C, S_DONE_1_C);
    type StateTypeArray is array (natural range <>) of StateType;
    signal state, nextState : StateTypeArray(1 downto 0);
-      
+
 begin
 
    -- check generic settings
    assert DMA_BUF_START_ADDR_G+(2**DMA_BUF_SIZE_BITS_G)*4 <= DMA_BUFF_MAX_ADDR_C
-      report "RceG3DmaQueue4x2: DMA buffer exceed maximum memory address"
-      severity failure;
-   
+                                                             report "RceG3DmaQueue4x2: DMA buffer exceed maximum memory address"
+                                                             severity failure;
+
    assert DMA_BUFF_COUNT_C >= 2
       report "RceG3DmaQueue4x2: DMA buffer size is not sufficient for selected MAX_CSPAD_PKT_SIZE_G"
       severity failure;
-   
+
    -- initialize buffer offsets
-   U_BuffOffGen: for i in 0 to DMA_BUFF_COUNT_C-1 generate
+   U_BuffOffGen : for i in 0 to DMA_BUFF_COUNT_C-1 generate
       buffOffsets(i) <= i*MAX_CSPAD_PKT_SIZE_G;
    end generate;
 
@@ -170,89 +170,73 @@ begin
 
    -- Unused Interrupts
    -- All unused for now
-   interrupt(DMA_INT_COUNT_C-1 downto 0) <= (others=>'0');
+   interrupt(DMA_INT_COUNT_C-1 downto 0) <= (others => '0');
 
    -- Unused DMA channels
-   dmaState                <= (others=>RCE_DMA_STATE_INIT_C);
-   dmaObMaster(3 downto 2) <= (others=>AXI_STREAM_MASTER_INIT_C);
+   dmaState <= (others => RCE_DMA_STATE_INIT_C);
+   dmaObMaster(3 downto 2) <= (others => AXI_STREAM_MASTER_INIT_C);
 
-   -- Terminate Unused AXI-Lite Interfaces
-   -- SW independent DMA therefore all unused for now
-   U_AxiLiteGen : for i in 0 to 8 generate
-      U_AxiLiteEmpty : entity work.AxiLiteEmpty
-         generic map (
-            TPD_G  => TPD_G
-         ) port map (
-            axiClk          => axiDmaClk,
-            axiClkRst       => axiDmaRst,
-            axiReadMaster   => axilReadMaster(i),
-            axiReadSlave    => axilReadSlave(i),
-            axiWriteMaster  => axilWriteMaster(i),
-            axiWriteSlave   => axilWriteSlave(i)
-         );
-   end generate;
-   
    ------------------------------------------
    -- Generate 4 DMA Write Channels
    ------------------------------------------
    U_DmaWriteGen : for i in 0 to 3 generate
-      
+
       -- Inbound AXI Stream FIFO
-      U_IbFifo : entity work.AxiStreamFifo 
+      U_IbFifo : entity work.AxiStreamFifo
          generic map (
-            TPD_G               => TPD_G,
-            PIPE_STAGES_G       => 1,
-            SLAVE_READY_EN_G    => true,
-            VALID_THOLD_G       => 1,
-            BRAM_EN_G           => true,
-            XIL_DEVICE_G        => "7SERIES",
-            USE_BUILT_IN_G      => false,
-            GEN_SYNC_FIFO_G     => true,
-            ALTERA_SYN_G        => false,
-            ALTERA_RAM_G        => "M9K",
-            CASCADE_SIZE_G      => 1,
-            FIFO_ADDR_WIDTH_G   => 9,
+            TPD_G => TPD_G,
+            PIPE_STAGES_G => 1,
+            SLAVE_READY_EN_G => true,
+            VALID_THOLD_G => 1,
+            BRAM_EN_G => true,
+            XIL_DEVICE_G => "7SERIES",
+            USE_BUILT_IN_G => false,
+            GEN_SYNC_FIFO_G => true,
+            ALTERA_SYN_G => false,
+            ALTERA_RAM_G => "M9K",
+            CASCADE_SIZE_G => 1,
+            FIFO_ADDR_WIDTH_G => 9,
             FIFO_FIXED_THRESH_G => true,
             FIFO_PAUSE_THRESH_G => 500,
-            SLAVE_AXI_CONFIG_G  => CUSTOM_AXIS_DMA_CONFIG_C,
+            SLAVE_AXI_CONFIG_G => CUSTOM_AXIS_DMA_CONFIG_C,
             MASTER_AXI_CONFIG_G => RCEG3_AXIS_DMA_CONFIG_C
-         ) port map (
-            sAxisClk        => dmaClk(i),
-            sAxisRst        => dmaClkRst(i),
-            sAxisMaster     => dmaIbMaster(i),
-            sAxisSlave      => dmaIbSlave(i),
-            sAxisCtrl       => open,
-            fifoPauseThresh => (others => '1'),
-            mAxisClk        => dmaClk(i),
-            mAxisRst        => dmaClkRst(i),
-            mAxisMaster     => sAxisMaster(i),
-            mAxisSlave      => sAxisSlave(i)
-         );
-      
+            ) port map (
+               sAxisClk => dmaClk(i),
+               sAxisRst => dmaClkRst(i),
+               sAxisMaster => dmaIbMaster(i),
+               sAxisSlave => dmaIbSlave(i),
+               sAxisCtrl => open,
+               fifoPauseThresh => (others => '1'),
+               mAxisClk => dmaClk(i),
+               mAxisRst => dmaClkRst(i),
+               mAxisMaster => sAxisMaster(i),
+               mAxisSlave => sAxisSlave(i)
+               );
+
       -- DMA writer instance
       U_WrDMA : entity work.AxiStreamDmaWrite
          generic map (
-            TPD_G             => TPD_G,
-            AXI_READY_EN_G    => false,
-            AXIS_CONFIG_G     => RCEG3_AXIS_DMA_CONFIG_C,
-            AXI_CONFIG_G      => AXI_HP_INIT_C,
-            AXI_BURST_G       => "01",
-            AXI_CACHE_G       => "0000"
-         ) port map (
-            axiClk            => dmaClk(i),
-            axiRst            => dmaClkRst(i),
-            -- DMA Control Interface
-            dmaReq            => ibReq(i),
-            dmaAck            => ibAck(i),
-            -- Streaming Interface 
-            axisMaster        => sAxisMaster(i),
-            axisSlave         => sAxisSlave(i),
-            -- AXI Interface
-            axiWriteMaster    => locWriteMaster(i),
-            axiWriteSlave     => locWriteSlave(i),
-            axiWriteCtrl      => locWriteCtrl(i)
-         );      
-      
+            TPD_G => TPD_G,
+            AXI_READY_EN_G => false,
+            AXIS_CONFIG_G => RCEG3_AXIS_DMA_CONFIG_C,
+            AXI_CONFIG_G => AXI_HP_INIT_C,
+            AXI_BURST_G => "01",
+            AXI_CACHE_G => "0000"
+            ) port map (
+               axiClk => dmaClk(i),
+               axiRst => dmaClkRst(i),
+               -- DMA Control Interface
+               dmaReq => ibReq(i),
+               dmaAck => ibAck(i),
+               -- Streaming Interface 
+               axisMaster => sAxisMaster(i),
+               axisSlave => sAxisSlave(i),
+               -- AXI Interface
+               axiWriteMaster => locWriteMaster(i),
+               axiWriteSlave => locWriteSlave(i),
+               axiWriteCtrl => locWriteCtrl(i)
+               );
+
       -- DMA writer request when SOF
       -- Do not start writer if all buffers are in use
       process (dmaClk(i))
@@ -267,7 +251,7 @@ begin
       end process;
       ibReq(i).request <= wrPending(i) and not ibAck(i).done;
       ibReq(i).drop <= '0';
-      
+
       -- Track write buffer index
       process (dmaClk(i))
       begin
@@ -281,151 +265,151 @@ begin
             end if;
          end if;
       end process;
-      
+
       ibReq(i).address <= CUSTOM_AXIS_DMA_ADDR_C(i) + buffOffsets(wrBuffIndex(i));
       ibReq(i).maxSize <= conv_std_logic_vector(MAX_CSPAD_PKT_SIZE_G, 32);
-      
+
       -- FIFO to store acknowledged bytes written by the DMA writer
-      U_WrDMA_Acq_FIFO: entity work.Fifo 
-      generic map (
-         RST_POLARITY_G    => '1',
-         DATA_WIDTH_G      => DMA_BUF_SIZE_BITS_G,
-         ADDR_WIDTH_G      => 8,
-         GEN_SYNC_FIFO_G   => true,
-         FWFT_EN_G         => true
-      )
-      port map ( 
-         rst               => dmaClkRst(i),
-         wr_clk            => dmaClk(i),
-         wr_en             => ibAck(i).done,
-         din               => ibAck(i).size(DMA_BUF_SIZE_BITS_G-1 downto 0),
-         wr_data_count     => open,
-         wr_ack            => open,
-         overflow          => open,
-         prog_full         => open,
-         almost_full       => open,
-         full              => ibAcqFifoWrFull(i),
-         not_full          => open,
-         rd_clk            => dmaClk(i),
-         rd_en             => ibAcqFifoRd(i),
-         dout              => ibAcqFifoOut(i),
-         rd_data_count     => open,
-         valid             => open,
-         underflow         => open,
-         prog_empty        => open,
-         almost_empty      => open,
-         empty             => ibAcqFifoEmpty(i)
-      );
+      U_WrDMA_Acq_FIFO : entity work.Fifo
+         generic map (
+            RST_POLARITY_G => '1',
+            DATA_WIDTH_G => DMA_BUF_SIZE_BITS_G,
+            ADDR_WIDTH_G => 8,
+            GEN_SYNC_FIFO_G => true,
+            FWFT_EN_G => true
+            )
+         port map (
+            rst => dmaClkRst(i),
+            wr_clk => dmaClk(i),
+            wr_en => ibAck(i).done,
+            din => ibAck(i).size(DMA_BUF_SIZE_BITS_G-1 downto 0),
+            wr_data_count => open,
+            wr_ack => open,
+            overflow => open,
+            prog_full => open,
+            almost_full => open,
+            full => ibAcqFifoWrFull(i),
+            not_full => open,
+            rd_clk => dmaClk(i),
+            rd_en => ibAcqFifoRd(i),
+            dout => ibAcqFifoOut(i),
+            rd_data_count => open,
+            valid => open,
+            underflow => open,
+            prog_empty => open,
+            almost_empty => open,
+            empty => ibAcqFifoEmpty(i)
+            );
 
       -- Write Path AXI FIFO
       U_AxiWritePathFifo : entity work.AxiWritePathFifo
          generic map (
-            TPD_G                    => TPD_G,
-            XIL_DEVICE_G             => "7SERIES",
-            USE_BUILT_IN_G           => false,
-            GEN_SYNC_FIFO_G          => false,
-            ALTERA_SYN_G             => false,
-            ALTERA_RAM_G             => "M9K",
-            ADDR_LSB_G               => 3,
-            ID_FIXED_EN_G            => true,
-            SIZE_FIXED_EN_G          => true,
-            BURST_FIXED_EN_G         => true,
-            LEN_FIXED_EN_G           => false,
-            LOCK_FIXED_EN_G          => true,
-            PROT_FIXED_EN_G          => true,
-            CACHE_FIXED_EN_G         => true,
-            ADDR_BRAM_EN_G           => true, 
-            ADDR_CASCADE_SIZE_G      => 1,
-            ADDR_FIFO_ADDR_WIDTH_G   => 9,
-            DATA_BRAM_EN_G           => true,
-            DATA_CASCADE_SIZE_G      => 1,
-            DATA_FIFO_ADDR_WIDTH_G   => 9,
+            TPD_G => TPD_G,
+            XIL_DEVICE_G => "7SERIES",
+            USE_BUILT_IN_G => false,
+            GEN_SYNC_FIFO_G => false,
+            ALTERA_SYN_G => false,
+            ALTERA_RAM_G => "M9K",
+            ADDR_LSB_G => 3,
+            ID_FIXED_EN_G => true,
+            SIZE_FIXED_EN_G => true,
+            BURST_FIXED_EN_G => true,
+            LEN_FIXED_EN_G => false,
+            LOCK_FIXED_EN_G => true,
+            PROT_FIXED_EN_G => true,
+            CACHE_FIXED_EN_G => true,
+            ADDR_BRAM_EN_G => true,
+            ADDR_CASCADE_SIZE_G => 1,
+            ADDR_FIFO_ADDR_WIDTH_G => 9,
+            DATA_BRAM_EN_G => true,
+            DATA_CASCADE_SIZE_G => 1,
+            DATA_FIFO_ADDR_WIDTH_G => 9,
             DATA_FIFO_PAUSE_THRESH_G => 456,
-            RESP_BRAM_EN_G           => false,
-            RESP_CASCADE_SIZE_G      => 1,
-            RESP_FIFO_ADDR_WIDTH_G   => 4,
-            AXI_CONFIG_G             => AXI_HP_INIT_C
-         ) port map (
-            sAxiClk         => dmaClk(i),
-            sAxiRst         => dmaClkRst(i),
-            sAxiWriteMaster => locWriteMaster(i),
-            sAxiWriteSlave  => locWriteSlave(i),
-            sAxiCtrl        => locWriteCtrl(i),
-            mAxiClk         => axiDmaClk,
-            mAxiRst         => axiDmaRst,
-            mAxiWriteMaster => intWriteMaster(i),
-            mAxiWriteSlave  => intWriteSlave(i)
-         );
+            RESP_BRAM_EN_G => false,
+            RESP_CASCADE_SIZE_G => 1,
+            RESP_FIFO_ADDR_WIDTH_G => 4,
+            AXI_CONFIG_G => AXI_HP_INIT_C
+            ) port map (
+               sAxiClk => dmaClk(i),
+               sAxiRst => dmaClkRst(i),
+               sAxiWriteMaster => locWriteMaster(i),
+               sAxiWriteSlave => locWriteSlave(i),
+               sAxiCtrl => locWriteCtrl(i),
+               mAxiClk => axiDmaClk,
+               mAxiRst => axiDmaRst,
+               mAxiWriteMaster => intWriteMaster(i),
+               mAxiWriteSlave => intWriteSlave(i)
+               );
    end generate;
 
    ------------------------------------------
    -- Generate 2 DMA Readers
    ------------------------------------------
    U_DmaReadGen : for i in 0 to 1 generate
-      
+
       -- Outbound AXI Stream FIFO
-      U_ObFifo : entity work.AxiStreamFifo 
+      U_ObFifo : entity work.AxiStreamFifo
          generic map (
-            TPD_G               => TPD_G,
-            PIPE_STAGES_G       => 1,
-            SLAVE_READY_EN_G    => false,
-            VALID_THOLD_G       => 1,
-            BRAM_EN_G           => true,
-            XIL_DEVICE_G        => "7SERIES",
-            USE_BUILT_IN_G      => false,
-            GEN_SYNC_FIFO_G     => true,
-            ALTERA_SYN_G        => false,
-            ALTERA_RAM_G        => "M9K",
-            CASCADE_SIZE_G      => 1,
-            FIFO_ADDR_WIDTH_G   => 9,
+            TPD_G => TPD_G,
+            PIPE_STAGES_G => 1,
+            SLAVE_READY_EN_G => false,
+            VALID_THOLD_G => 1,
+            BRAM_EN_G => true,
+            XIL_DEVICE_G => "7SERIES",
+            USE_BUILT_IN_G => false,
+            GEN_SYNC_FIFO_G => true,
+            ALTERA_SYN_G => false,
+            ALTERA_RAM_G => "M9K",
+            CASCADE_SIZE_G => 1,
+            FIFO_ADDR_WIDTH_G => 9,
             FIFO_FIXED_THRESH_G => true,
             FIFO_PAUSE_THRESH_G => 475,
-            SLAVE_AXI_CONFIG_G  => RCEG3_AXIS_DMA_CONFIG_C,
+            SLAVE_AXI_CONFIG_G => RCEG3_AXIS_DMA_CONFIG_C,
             MASTER_AXI_CONFIG_G => CUSTOM_AXIS_DMA_CONFIG_C
-         ) port map (
-            sAxisClk        => dmaClk(i),
-            sAxisRst        => dmaClkRst(i),
-            sAxisMaster     => mAxisMaster(i),
-            sAxisSlave      => mAxisSlave(i),
-            sAxisCtrl       => mAxisCtrl(i),
-            fifoPauseThresh => (others => '1'),
-            mAxisClk        => dmaClk(i),
-            mAxisRst        => dmaClkRst(i),
-            mAxisMaster     => dmaObMaster(i),
-            mAxisSlave      => dmaObSlave(i)
-         );
-         
-         
-      U_RdDMA : entity work.AxiStreamDmaRead 
+            ) port map (
+               sAxisClk => dmaClk(i),
+               sAxisRst => dmaClkRst(i),
+               sAxisMaster => mAxisMaster(i),
+               sAxisSlave => mAxisSlave(i),
+               sAxisCtrl => mAxisCtrl(i),
+               fifoPauseThresh => (others => '1'),
+               mAxisClk => dmaClk(i),
+               mAxisRst => dmaClkRst(i),
+               mAxisMaster => dmaObMaster(i),
+               mAxisSlave => dmaObSlave(i)
+               );
+
+
+      U_RdDMA : entity work.AxiStreamDmaRead
          generic map (
-            TPD_G            => TPD_G,
-            AXIS_READY_EN_G  => false,
-            AXIS_CONFIG_G    => RCEG3_AXIS_DMA_CONFIG_C,
-            AXI_CONFIG_G     => AXI_HP_INIT_C,
-            AXI_BURST_G      => "01",
-            AXI_CACHE_G      => "0000"
-         ) port map (
-            axiClk          => dmaClk(i),
-            axiRst          => dmaClkRst(i),
-            dmaReq          => obReq(i),
-            dmaAck          => obAck(i),
-            axisMaster      => mAxisMaster(i),
-            axisSlave       => mAxisSlave(i),
-            axisCtrl        => mAxisCtrl(i),
-            axiReadMaster   => locReadMaster(i),
-            axiReadSlave    => locReadSlave(i)
-         );
-      
+            TPD_G => TPD_G,
+            AXIS_READY_EN_G => false,
+            AXIS_CONFIG_G => RCEG3_AXIS_DMA_CONFIG_C,
+            AXI_CONFIG_G => AXI_HP_INIT_C,
+            AXI_BURST_G => "01",
+            AXI_CACHE_G => "0000"
+            ) port map (
+               axiClk => dmaClk(i),
+               axiRst => dmaClkRst(i),
+               dmaReq => obReq(i),
+               dmaAck => obAck(i),
+               axisMaster => mAxisMaster(i),
+               axisSlave => mAxisSlave(i),
+               axisCtrl => mAxisCtrl(i),
+               axiReadMaster => locReadMaster(i),
+               axiReadSlave => locReadSlave(i)
+               );
+
       -- one read channel handles data from two write channels
       process (state(i), ibAcqFifoEmpty(i*2), ibAcqFifoEmpty(i*2+1), obAck(i).done)
       begin
-         
+
          wrChannelSel(i) <= 0;
          obReq(i).request <= '0';
          ibAcqFifoRd(i*2) <= '0';
          ibAcqFifoRd(i*2+1) <= '0';
          nextState(i) <= state(i);
-         
+
          case state(i) is
 
             when S_IDLE_C =>
@@ -436,7 +420,7 @@ begin
                   nextState(i) <= S_READ_1_C;
                   wrChannelSel(i) <= 1;
                end if;
-            
+
             when S_READ_0_C =>
                obReq(i).request <= '1';
                wrChannelSel(i) <= 0;
@@ -445,7 +429,7 @@ begin
                   ibAcqFifoRd(i*2) <= '1';
                   nextState(i) <= S_DONE_0_C;
                end if;
-            
+
             when S_DONE_0_C =>
                wrChannelSel(i) <= 0;
                if ibAcqFifoEmpty(i*2+1) = '0' then
@@ -455,7 +439,7 @@ begin
                else
                   nextState(i) <= S_IDLE_C;
                end if;
-            
+
             when S_READ_1_C =>
                obReq(i).request <= '1';
                wrChannelSel(i) <= 1;
@@ -464,7 +448,7 @@ begin
                   ibAcqFifoRd(i*2+1) <= '1';
                   nextState(i) <= S_DONE_1_C;
                end if;
-            
+
             when S_DONE_1_C =>
                wrChannelSel(i) <= 1;
                if ibAcqFifoEmpty(i*2) = '0' then
@@ -474,19 +458,19 @@ begin
                else
                   nextState(i) <= S_IDLE_C;
                end if;
-            
+
          end case;
-      
+
       end process;
-      
+
       obReq(i).address <= CUSTOM_AXIS_DMA_ADDR_C(i*2) + buffOffsets(rdBuffIndex(i*2)) when wrChannelSel(i) = 0 else CUSTOM_AXIS_DMA_ADDR_C(i*2+1) + buffOffsets(rdBuffIndex(i*2+1));
-      obReq(i).size(31 downto DMA_BUF_SIZE_BITS_G) <= (others=>'0');
+      obReq(i).size(31 downto DMA_BUF_SIZE_BITS_G) <= (others => '0');
       obReq(i).size(DMA_BUF_SIZE_BITS_G-1 downto 0) <= ibAcqFifoOut(i*2) when wrChannelSel(i) = 0 else ibAcqFifoOut(i*2+1);
       obReq(i).firstUser <= "00000010";
-      obReq(i).lastUser <= (others=>'0');
-      obReq(i).dest <= (others=>'0');
-      obReq(i).id <= (others=>'0');
-      
+      obReq(i).lastUser <= (others => '0');
+      obReq(i).dest <= (others => '0');
+      obReq(i).id <= (others => '0');
+
       process (dmaClk(i))
       begin
          if rising_edge(dmaClk(i)) then
@@ -497,12 +481,12 @@ begin
             end if;
          end if;
       end process;
-      
-      
+
+
       -- Separetly for each write channel track
       -- read address and memory buffer usage
       U_DmaRdAddrGen : for j in 0 to 1 generate
-         
+
          -- Read buffer index
          process (dmaClk(i))
          begin
@@ -516,21 +500,21 @@ begin
                end if;
             end if;
          end process;
-         
+
          -- Buffer usage counter
          process (dmaClk(i))
          begin
             if rising_edge(dmaClk(i)) then
                if dmaClkRst(i) = '1' then
                   cntUsedBuff(i*2+j) <= 0 after TPD_G;
-               elsif obAck(i).done = '1' and wrChannelSel(i) = j then   -- subtract when reader is done
+               elsif obAck(i).done = '1' and wrChannelSel(i) = j then  -- subtract when reader is done
                   cntUsedBuff(i*2+j) <= cntUsedBuff(i*2+j) - 1 after TPD_G;
-               elsif ibAckRes(i*2+j) = '1' then                         -- add when writer is done
+               elsif ibAckRes(i*2+j) = '1' then  -- add when writer is done
                   cntUsedBuff(i*2+j) <= cntUsedBuff(i*2+j) + 1 after TPD_G;
                end if;
             end if;
          end process;
-         
+
          -- Memory usage counter signal 
          -- protected against simultaneous arrival of done from both writer and reader
          process (dmaClk(i))
@@ -543,9 +527,9 @@ begin
                end if;
             end if;
          end process;
-         
+
          ibAckRes(i*2+j) <= (ibAck(i*2+j).done and obAck(i).done) or (ibAckDoneD1(i*2+j) and not obAck(i).done);
-         
+
          -- Generate back pressure signals when the reader is too slow
          --process (dmaClk(i))
          --begin
@@ -564,45 +548,45 @@ begin
          --      end if;
          --   end if;
          --end process;
-      
+
       end generate;
 
 
       -- Read Path AXI FIFO
-      U_AxiReadPathFifo : entity work.AxiReadPathFifo 
+      U_AxiReadPathFifo : entity work.AxiReadPathFifo
          generic map (
-            TPD_G                    => TPD_G,
-            XIL_DEVICE_G             => "7SERIES",
-            USE_BUILT_IN_G           => false,
-            GEN_SYNC_FIFO_G          => false,
-            ALTERA_SYN_G             => false,
-            ALTERA_RAM_G             => "M9K",
-            ADDR_LSB_G               => 3,
-            ID_FIXED_EN_G            => true,
-            SIZE_FIXED_EN_G          => true,
-            BURST_FIXED_EN_G         => true,
-            LEN_FIXED_EN_G           => false,
-            LOCK_FIXED_EN_G          => true,
-            PROT_FIXED_EN_G          => true,
-            CACHE_FIXED_EN_G         => true,
-            ADDR_BRAM_EN_G           => false, 
-            ADDR_CASCADE_SIZE_G      => 1,
-            ADDR_FIFO_ADDR_WIDTH_G   => 4,
-            DATA_BRAM_EN_G           => false,
-            DATA_CASCADE_SIZE_G      => 1,
-            DATA_FIFO_ADDR_WIDTH_G   => 4,
-            AXI_CONFIG_G             => AXI_HP_INIT_C
-         ) port map (
-            sAxiClk        => dmaClk(i),
-            sAxiRst        => dmaClkRst(i),
-            sAxiReadMaster => locReadMaster(i),
-            sAxiReadSlave  => locReadSlave(i),
-            mAxiClk        => axiDmaClk,
-            mAxiRst        => axiDmaRst,
-            mAxiReadMaster => intReadMaster(i),
-            mAxiReadSlave  => intReadSlave(i)
-         );
-      
+            TPD_G => TPD_G,
+            XIL_DEVICE_G => "7SERIES",
+            USE_BUILT_IN_G => false,
+            GEN_SYNC_FIFO_G => false,
+            ALTERA_SYN_G => false,
+            ALTERA_RAM_G => "M9K",
+            ADDR_LSB_G => 3,
+            ID_FIXED_EN_G => true,
+            SIZE_FIXED_EN_G => true,
+            BURST_FIXED_EN_G => true,
+            LEN_FIXED_EN_G => false,
+            LOCK_FIXED_EN_G => true,
+            PROT_FIXED_EN_G => true,
+            CACHE_FIXED_EN_G => true,
+            ADDR_BRAM_EN_G => false,
+            ADDR_CASCADE_SIZE_G => 1,
+            ADDR_FIFO_ADDR_WIDTH_G => 4,
+            DATA_BRAM_EN_G => false,
+            DATA_CASCADE_SIZE_G => 1,
+            DATA_FIFO_ADDR_WIDTH_G => 4,
+            AXI_CONFIG_G => AXI_HP_INIT_C
+            ) port map (
+               sAxiClk => dmaClk(i),
+               sAxiRst => dmaClkRst(i),
+               sAxiReadMaster => locReadMaster(i),
+               sAxiReadSlave => locReadSlave(i),
+               mAxiClk => axiDmaClk,
+               mAxiRst => axiDmaRst,
+               mAxiReadMaster => intReadMaster(i),
+               mAxiReadSlave => intReadSlave(i)
+               );
+
    end generate;
 
 end structure;


### PR DESCRIPTION
Updated for compatibility with SURF v1.7.0.
 * Removed all AXI_ERROR_RESP_G generics
 * Removed all AxiLiteEmpty instances