### PR TITLE
Reduce DMA descriptor counts from 4096 to 1024

### DIFF
--- a/RceG3/hdl/RceG3DmaAxisChan.vhd
+++ b/RceG3/hdl/RceG3DmaAxisChan.vhd
@@ -85,7 +85,7 @@ begin
    U_AxiStreamDma : entity work.AxiStreamDma
       generic map (
          TPD_G             => TPD_G,
-         FREE_ADDR_WIDTH_G => 12,    -- 4096 entries
+         FREE_ADDR_WIDTH_G => 10,    -- 1024 entries
          AXIL_COUNT_G      => 2,
          AXIL_BASE_ADDR_G  => x"00000000",
          AXI_READY_EN_G    => false,

--- a/RceG3/hdl/RceG3DmaAxisV2.vhd
+++ b/RceG3/hdl/RceG3DmaAxisV2.vhd
@@ -112,7 +112,7 @@ begin
    interrupt(DMA_INT_COUNT_C-1 downto 4) <= (others => '0');
 
    -------------------------------------------
-   -- Version 2 DMA Core For Ethernet
+   -- Version 2 DMA Core 
    -------------------------------------------
    U_Gen2Dma: for i in 0 to 2 generate
       U_RceG3DmaAxisChan: entity work.RceG3DmaAxisV2Chan

--- a/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
+++ b/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
@@ -240,7 +240,7 @@ begin
    U_AxiStreamDmaV2: entity work.AxiStreamDmaV2 
       generic map (
          TPD_G             => TPD_G,
-         DESC_AWIDTH_G     => 12,
+         DESC_AWIDTH_G     => 10,
          AXIL_BASE_ADDR_G  => AXIL_BASE_ADDR_G,
          AXI_READY_EN_G    => false,
          AXIS_READY_EN_G   => false,


### PR DESCRIPTION
We have not used more than 1000 descriptors in any application.