### PR TITLE
restore dma buffer count

### DIFF
--- a/RceG3/hdl/RceG3DmaAxisChan.vhd
+++ b/RceG3/hdl/RceG3DmaAxisChan.vhd
@@ -85,7 +85,7 @@ begin
    U_AxiStreamDma : entity work.AxiStreamDma
       generic map (
          TPD_G             => TPD_G,
-         FREE_ADDR_WIDTH_G => 10,    -- 1024 entries
+         FREE_ADDR_WIDTH_G => 12,
          AXIL_COUNT_G      => 2,
          AXIL_BASE_ADDR_G  => x"00000000",
          AXI_READY_EN_G    => false,

--- a/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
+++ b/RceG3/hdl/RceG3DmaAxisV2Chan.vhd
@@ -240,7 +240,7 @@ begin
    U_AxiStreamDmaV2: entity work.AxiStreamDmaV2 
       generic map (
          TPD_G             => TPD_G,
-         DESC_AWIDTH_G     => 10,
+         DESC_AWIDTH_G     => 12,
          AXIL_BASE_ADDR_G  => AXIL_BASE_ADDR_G,
          AXI_READY_EN_G    => false,
          AXIS_READY_EN_G   => false,


### PR DESCRIPTION
This broke the 10G ethernet path since it uses 2048 buffers. We also don't seem to need this to get HLS to compile.