### PR TITLE
Compatibility fixes for surf v2.18.1 (and probably earlier)

### DIFF
--- a/PpiPgp/hdl/PgpToPpi.vhd
+++ b/PpiPgp/hdl/PgpToPpi.vhd
@@ -225,7 +225,7 @@ begin
    -- Generate overflow pulse in ppi clock domain
    U_SyncOverflow : entity surf.SynchronizerOneShot 
       generic map (
-         RELEASE_DELAY_G => 3,
+         OUT_DELAY_G     => 3,
          BYPASS_SYNC_G   => false,
          TPD_G           => TPD_G,
          RST_POLARITY_G  => '1',
@@ -242,7 +242,7 @@ begin
    -- Generate pause pulse in ppi clock domain
    U_SyncPause : entity surf.SynchronizerOneShot 
       generic map (
-         RELEASE_DELAY_G => 3,
+         OUT_DELAY_G     => 3,
          BYPASS_SYNC_G   => false,
          TPD_G           => TPD_G,
          RST_POLARITY_G  => '1',

--- a/PpiPgp/hdl/PpiPgpArray.vhd
+++ b/PpiPgp/hdl/PpiPgpArray.vhd
@@ -64,6 +64,7 @@ entity PpiPgpArray is
       pgpTxClk     : in  slv(NUM_LANES_G-1 downto 0);
       pgpTxClkRst  : in  slv(NUM_LANES_G-1 downto 0);
       pgpTxIn      : out Pgp2bTxInArray(NUM_LANES_G-1 downto 0);
+      locTxIn      : in  Pgp2bTxInArray(NUM_LANES_G-1 downto 0) := (others => PGP2B_TX_IN_INIT_C);
       pgpTxOut     : in  Pgp2bTxOutArray(NUM_LANES_G-1 downto 0);
       pgpTxMasters : out AxiStreamQuadMasterArray(NUM_LANES_G-1 downto 0);
       pgpTxSlaves  : in  AxiStreamQuadSlaveArray(NUM_LANES_G-1 downto 0);
@@ -200,6 +201,7 @@ begin
                pgpTxClk         => pgpTxClk(i),
                pgpTxClkRst      => pgpTxClkRst(i),
                pgpTxIn          => pgpTxIn(i),
+               locTxIn          => locTxIn(i),
                pgpTxOut         => pgpTxOut(i),
                pgpTxMasters     => pgpTxMasters(i),
                pgpTxSlaves      => pgpTxSlaves(i),

--- a/PpiPgp/hdl/PpiPgpLane.vhd
+++ b/PpiPgp/hdl/PpiPgpLane.vhd
@@ -63,6 +63,7 @@ entity PpiPgpLane is
       pgpTxClk          : in  sl;
       pgpTxClkRst       : in  sl;
       pgpTxIn           : out Pgp2bTxInType;
+      locTxIn           : in  Pgp2bTxInType := PGP2B_TX_IN_INIT_C;
       pgpTxOut          : in  Pgp2bTxOutType;
       pgpTxMasters      : out AxiStreamMasterArray(3 downto 0);
       pgpTxSlaves       : in  AxiStreamSlaveArray(3 downto 0);
@@ -110,6 +111,7 @@ begin
          pgpTxClk          => pgpTxClk,
          pgpTxClkRst       => pgpTxClkRst,
          pgpTxIn           => pgpTxIn,
+         locTxIn           => locTxIn,
          pgpTxOut          => pgpTxOut,
          pgpRxClk          => pgpRxClk,
          pgpRxClkRst       => pgpRxClkRst,

--- a/RceEthernet/rtl/RceEthernetReg.vhd
+++ b/RceEthernet/rtl/RceEthernetReg.vhd
@@ -62,8 +62,9 @@ end RceEthernetReg;
 
 architecture structure of RceEthernetReg is
 
-   constant STATUS_SIZE_C : positive                      := 17;
-   constant ROLL_OVER_C   : slv(STATUS_SIZE_C-1 downto 0) := toSlv(3, STATUS_SIZE_C);
+   constant STATUS_SIZE_C  : positive                      := 17;
+   constant ROLL_OVER_C    : slv(STATUS_SIZE_C-1 downto 0) := toSlv(3, STATUS_SIZE_C);
+   constant PAUSE_THRESH_C : slv(15 downto 0) := toSlv(9000/16, 16); -- 9000B jumbo frame in cache
 
    type RegType is record
       countReset     : sl;
@@ -220,6 +221,7 @@ begin
    end process;
 
    macConfig.pauseEnable <= '1';
+   macConfig.pauseThresh <= PAUSE_THRESH_C;
 
    U_SyncMAC : entity surf.SynchronizerVector
       generic map (


### PR DESCRIPTION
When I updated to the most recent release, I found a couple of issues in the RCE code that I guess no one had run up against, and one thing that I needed for LSST. They are broken into the 3 commits of this pull request.

1. In RceEthernet, there was no default in the macConfig for the pause threshold. This caused pause frames to be sent continuously. I have set it here to the same value that I saw elsewhere, which is 1 Jumbo Frame.
2. There was a change in the name for the generic of the surf.SynchronizerOneShot from RELEASE_DELAY to OUT_DELAY that wasn't propagated to PgpToPpi.vhd.
3. LSST needs to have the PGP locTxIn exposed to the user to send synchronous commands. This commit doesn't fit the others in this pull request, but it didn't seem worth creating a second one.