### PR TITLE
Preventing ASYNC reset signals

### DIFF
--- a/PpiCommon/hdl/PpiObPayload.vhd
+++ b/PpiCommon/hdl/PpiObPayload.vhd
@@ -346,6 +346,9 @@ begin
 
       end case;
 
+      -- Combinatorial output
+      obPendSlave <= v.hAxisSlave;
+
       -- Reset
       if axiRst = '1' then
          v := REG_INIT_C;
@@ -357,7 +360,6 @@ begin
       -- Outputs
       dmaReq         <= r.dmaReq;
       obAxiError     <= r.rdError;
-      obPendSlave    <= v.hAxisSlave;
       intAxisMaster  <= r.fAxisMaster;
       compWrite      <= r.compWrite;
       obPayloadDebug <= r.obPayloadDebug;

--- a/PpiCommon/hdl/PpiToAxiLite.vhd
+++ b/PpiCommon/hdl/PpiToAxiLite.vhd
@@ -478,6 +478,9 @@ begin
 
       end case;
 
+      -- Combinatorial output
+      intObSlave <= v.intObSlave;
+
       -- Reset
       if axilClkRst = '1' then
          v := REG_INIT_C;
@@ -490,7 +493,6 @@ begin
       axilReadMaster  <= r.axilReadMaster;
       axilWriteMaster <= r.axilWriteMaster;
       intIbMaster     <= r.intIbMaster;
-      intObSlave      <= v.intObSlave;
 
    end process;
 

--- a/PpiPgp/hdl/PgpToPpi.vhd
+++ b/PpiPgp/hdl/PgpToPpi.vhd
@@ -338,6 +338,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial output
+      intIbSlave <= v.intIbSlave;
+
       -- Reset
       if ppiClkRst = '1' or ppiState.online = '0' then
          v := REG_INIT_C;
@@ -350,7 +353,6 @@ begin
       dataIn        <= r.dataIn;
       headerIn      <= r.headerIn;
       rxFrameCntEn  <= r.headerIn.valid;
-      intIbSlave    <= v.intIbSlave;
 
    end process;
 
@@ -542,6 +544,9 @@ begin
 
       end case;
 
+      -- Combinatorial output
+      dataRead <= v.dataRead;
+
       -- Reset
       if ppiClkRst = '1' then
          v := REG_MOVE_INIT_C;
@@ -553,7 +558,6 @@ begin
       -- Outputs
       regIbMaster <= rm.regIbMaster;
       headerRead  <= rm.headerRead;
-      dataRead    <= v.dataRead;
 
    end process;
 

--- a/PpiPgp/hdl/PpiToPgp.vhd
+++ b/PpiPgp/hdl/PpiToPgp.vhd
@@ -253,6 +253,9 @@ begin
             end if;
       end case;
 
+      -- Combinatorial output
+      ippiObSlave <= v.ippiObSlave;
+
       -- Reset
       if ppiClkRst = '1' then
          v := REG_INIT_C;
@@ -263,7 +266,6 @@ begin
 
       -- Outputs
       iaxisObMaster <= r.iaxisObMaster;
-      ippiObSlave   <= v.ippiObSlave;
       txFrameCntEn  <= r.txFrameCntEn;
 
    end process;

--- a/RceEthernet/rtl/RceEthernetMac.vhd
+++ b/RceEthernet/rtl/RceEthernetMac.vhd
@@ -378,6 +378,10 @@ begin
             end if;
          end if;
 
+         -- Combinatorial output
+         rxSlave <= v.rxSlave;
+         txSlave <= v.txSlave;
+
          -- Reset
          if (dmaRst = '1') then
             v := REG_INIT_C;
@@ -387,8 +391,6 @@ begin
          rin <= v;
 
          -- Outputs        
-         rxSlave      <= v.rxSlave;
-         txSlave      <= v.txSlave;
          dmaIbMaster  <= r.dmaIbMaster;
          ibPrimMaster <= r.ibPrimMaster;
 

--- a/RceEthernet/rtl/RceUserEthRouter.vhd
+++ b/RceEthernet/rtl/RceUserEthRouter.vhd
@@ -355,6 +355,9 @@ begin
             v.cnt      := 0;
          end if;
 
+         -- Combinatorial output
+         obMacPrimSlave <= v.obMacPrimSlave;
+
          -- Reset
          if (ethRst = '1') then
             v := REG_INIT_C;
@@ -364,7 +367,6 @@ begin
          rin <= v;
 
          -- Outputs       
-         obMacPrimSlave <= v.obMacPrimSlave;
          txMaster       <= r.txMaster;
          ethUdpObMaster <= r.ethUdpObMaster;
 


### PR DESCRIPTION
### Description
- Combinatorial outputs must be sent before the `Reset` else the output becomes an ASYNC reset
- Related to https://github.com/slaclab/surf/pull/170