### PR TITLE
Remove Python Version Limitation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-Copyright (c) 2021, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2023, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,14 +10,14 @@ build:
 
 requirements:
    build:
-     - python<3.8
+     - python
      - rogue
      - git
      - gitpython
      - numpy
 
    run:
-     - python<3.8
+     - python
      - rogue
      - numpy
 


### PR DESCRIPTION
The previous version had python locked to 3.7 which was making it hard to find solutions. This opens up the python verion.