### PR TITLE
Repo hygiene: pin/upgrade Actions to SHAs

### DIFF
--- a/.github/workflows/rce_gw_ci.yml
+++ b/.github/workflows/rce_gw_ci.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.12
 


### PR DESCRIPTION
## Repo hygiene

- Upgrade third-party GitHub Actions to latest release, pinned to commit SHA (tag in trailing comment)

First-party `slaclab/ruckus` reusable workflows remain on `@main`.

### Verification
- [x] CI passes with upgraded, SHA-pinned actions
- [x] `LICENSE.txt` present with `Copyright (c) 2026`
